### PR TITLE
Replace gl-matrix with gl-mat4; add missing dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ Example
 var shell = require("gl-now")()
 var camera = require("game-shell-orbit-camera")(shell)
 var renderText = require("gl-render-text")
+var mat4 = require("gl-mat4")
 var drawBillboard = require("draw-billboard")
-var mat4 = require("gl-matrix").mat4
 
 var texture
 var positions = new Array(100)

--- a/billboard.js
+++ b/billboard.js
@@ -2,8 +2,7 @@
 
 var createShader = require("gl-shader")
 var createMesh = require("gl-mesh")
-var glm = require("gl-matrix")
-var mat4 = glm.mat4
+var mat4 = require("gl-mat4")
 
 function createBillboardMesh(gl) {
   var mesh = createMesh(gl, [[1,0,2], [1,2,3]], {

--- a/example/example.js
+++ b/example/example.js
@@ -3,7 +3,7 @@
 var shell = require("gl-now")()
 var camera = require("game-shell-orbit-camera")(shell)
 var renderText = require("gl-render-text")
-var mat4 = require("gl-matrix").mat4
+var mat4 = require("gl-mat4")
 var drawBillboard = require("../billboard.js")
 
 var texture

--- a/package.json
+++ b/package.json
@@ -7,13 +7,13 @@
     "example": "example"
   },
   "dependencies": {
+    "gl-mat4": "^1.1.2",
     "gl-mesh": "~0.1.0",
     "gl-shader": "~0.0.6"
   },
   "devDependencies": {
     "gl-render-text": "~0.0.0",
     "game-shell-orbit-camera": "~0.0.0",
-    "gl-matrix": "~2.0.0",
     "gl-now": "~0.0.4"
   },
   "scripts": {


### PR DESCRIPTION
billboard.js requires gl-matrix but this module is not listed in the package.json dependencies, only devDependencies, so require('draw-billboard') fails:

```
Error: Cannot find module 'gl-matrix' from 'node_modules/draw-billboard'
    at /usr/local/lib/node_modules/browserify/node_modules/browser-resolve/node_modules/resolve/lib/async.js:51:17
    at process (/usr/local/lib/node_modules/browserify/node_modules/browser-resolve/node_modules/resolve/lib/async.js:159:43)
    at /usr/local/lib/node_modules/browserify/node_modules/browser-resolve/node_modules/resolve/lib/async.js:168:21
    at load (/usr/local/lib/node_modules/browserify/node_modules/browser-resolve/node_modules/resolve/lib/async.js:99:43)
    at /usr/local/lib/node_modules/browserify/node_modules/browser-resolve/node_modules/resolve/lib/async.js:105:22
    at /usr/local/lib/node_modules/browserify/node_modules/browser-resolve/node_modules/resolve/lib/async.js:22:47
    at Object.oncomplete (fs.js:107:15)
```

the dependency should be moved from devDependencies to dependencies to fix this.

(But since [gl-mat4](https://github.com/stackgl/gl-mat4) is now available as an alternative to pulling in gl-matrix just for mat4, I also switched to it as part of this pull request.)
